### PR TITLE
SAML login support added 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ad-azure-auth",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An React Native module implements Azure AD V2.0 authentication flow",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/src/webauth/agent.js
+++ b/src/webauth/agent.js
@@ -14,13 +14,13 @@ export default class Agent {
         return new Promise((resolve, reject) => {
             const urlHandler = (event) => {
                 NativeModules.AzureAuth.hide()
-                Linking.removeEventListener('url', urlHandler)
+                Linking.removeAllListeners('url')
                 resolve(event.url)
             }
             const params = Platform.OS === 'ios' ? [ephemeralSession, closeOnLoad] : [closeOnLoad]
             Linking.addEventListener('url', urlHandler)
             NativeModules.AzureAuth.showUrl(url, ...params, (err, redirectURL) => {
-                Linking.removeEventListener('url', urlHandler)
+                Linking.removeAllListeners('url')
                 if (err) {
                     reject(err)
                 } else if(redirectURL) {

--- a/src/webauth/index.js
+++ b/src/webauth/index.js
@@ -113,6 +113,25 @@ export default class WebAuth {
         }
     }
 
+    async authorizeSAML(options = {}) {
+        const {  client, agent } = this
+        const loginUrl =  this.client.authorityUrl
+        let redirectUrl = await agent.openWeb(loginUrl, options.ephemeralSession)
+
+        if (!redirectUrl || !redirectUrl.startsWith(client.redirectUri)) {
+            throw new AuthError({
+                json: {
+                    error: 'aa.redirect_uri.not_expected',
+                    error_description: `Expected ${client.redirectUri} but got ${redirectUrl}`
+                },
+                status: 0
+            })
+        }
+
+        const urlHashParsed = url.parse(redirectUrl).query
+        return urlHashParsed
+    }
+
     
     /**
    *  Removes Azure session using v2.0
@@ -124,8 +143,8 @@ export default class WebAuth {
    *
    * @memberof WebAuth
    */
-     clearSession({ephemeralSession = true, closeOnLoad = true} = {}) {
-        const options = { ephemeralSession, closeOnLoad };
+    clearSession({ephemeralSession = true, closeOnLoad = true} = {}) {
+        const options = { ephemeralSession, closeOnLoad }
         const { client, agent } = this
         const parsedOptions = validate({
             parameters: {
@@ -149,8 +168,8 @@ export default class WebAuth {
    *
    * @memberof WebAuth
    */
-     clearSessionV1({ephemeralSession = true, closeOnLoad = true} = {}) {
-        const options = { ephemeralSession, closeOnLoad };
+    clearSessionV1({ephemeralSession = true, closeOnLoad = true} = {}) {
+        const options = { ephemeralSession, closeOnLoad }
         const { client, agent } = this
         const parsedOptions = validate({
             parameters: {
@@ -160,7 +179,7 @@ export default class WebAuth {
             validate: true // not declared params are NOT allowed:
         }, options)
 
-        const logoutUrl = "https://login.microsoftonline.com/common/oauth2/logout"
+        const logoutUrl = 'https://login.microsoftonline.com/common/oauth2/logout'
         return agent.openWeb(logoutUrl, parsedOptions.ephemeralSession, parsedOptions.closeOnLoad)
     }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -314,6 +314,12 @@ declare class WebAuth {
     scope?: string;
     claims?: string;
   }): Promise<BaseTokenItem & Partial<AccessTokenItem>>;
+
+  authorizeSAML(options: {
+    prompt?: string;
+    scope?: string;
+    claims?: string;
+  }): Promise<BaseTokenItem & Partial<AccessTokenItem>>;
   /**
    *  Removes Azure session
    *


### PR DESCRIPTION
export const loginWithAzure = async (): Promise<any> => {
  const authObject = {
    scope: 'openid email User.Read',
    prompt: 'login', // Always asks for password
  };
 
  try {
    return await azureAuth.webAuth.authorizeSAML(authObject);
  } catch (error: any) {
    console.log('error loginWithAzure', error);

    if (error.error !== 'aa.session.user_cancelled') {
      showToast(error.error_description ?? '');
    }
    return null;
  }
};